### PR TITLE
Fix missing os import in wb_data plugin

### DIFF
--- a/plugins/steps/wb_data.py
+++ b/plugins/steps/wb_data.py
@@ -3,6 +3,7 @@ from collections import defaultdict
 import sys
 import json
 import logging
+import os
 from typing import Dict, List
 
 import pandas as pd


### PR DESCRIPTION
## Summary
- import `os` in `plugins/steps/wb_data.py` to support file system checks during SQLite fallback

## Testing
- `python -m py_compile plugins/steps/wb_data.py`
- `pytest` *(fails: HookspecMarker.__call__() got an unexpected keyword argument 'warn_on_impl_args')*


------
https://chatgpt.com/codex/tasks/task_e_68a33a2659e88332a938bcf946df91b9